### PR TITLE
Changes in the return of of synthesize functions

### DIFF
--- a/MilneEddington.py
+++ b/MilneEddington.py
@@ -135,7 +135,7 @@ class MilneEddington:
 
             
             
-        return self.Me.synthesize(model, mu=mu)
+        return self.Me.synthesize(model1, mu=mu)
 
 
     # *************************************************************************************************
@@ -186,7 +186,7 @@ class MilneEddington:
 
             
             
-        return self.Me.synthesize_RF(model, mu=mu)
+        return self.Me.synthesize_RF(model1, mu=mu)
 
     # *************************************************************************************************
       


### PR DESCRIPTION
I noticed that, in functions synthesize_rf and synthesize, the return is were using the same 'model' variables as in the input. It was causing some errors in my tests. 